### PR TITLE
Add parameter key to EncodeValues

### DIFF
--- a/query/encode.go
+++ b/query/encode.go
@@ -38,7 +38,7 @@ var encoderType = reflect.TypeOf(new(Encoder)).Elem()
 // Encoder is an interface implemented by any type that wishes to encode
 // itself into URL values in a non-standard way.
 type Encoder interface {
-	EncodeValues(v *url.Values) error
+	EncodeValues(key string, v *url.Values) error
 }
 
 // Values returns the url.Values encoding of v.
@@ -154,7 +154,7 @@ func reflectValue(values url.Values, val reflect.Value) error {
 
 		if sv.Type().Implements(encoderType) {
 			m := sv.Interface().(Encoder)
-			if err := m.EncodeValues(&values); err != nil {
+			if err := m.EncodeValues(name, &values); err != nil {
 				return err
 			}
 			continue

--- a/query/encode_test.go
+++ b/query/encode_test.go
@@ -191,16 +191,16 @@ func TestValues_invalidInput(t *testing.T) {
 
 type EncodedArgs []string
 
-func (m EncodedArgs) EncodeValues(v *url.Values) error {
+func (m EncodedArgs) EncodeValues(key string, v *url.Values) error {
 	for i, arg := range m {
-		v.Set(fmt.Sprintf("arg.%d", i), arg)
+		v.Set(fmt.Sprintf("%s.%d", key, i), arg)
 	}
 	return nil
 }
 
 func TestValues_Marshaler(t *testing.T) {
 	s := struct {
-		Args EncodedArgs `url:"args"`
+		Args EncodedArgs `url:"arg"`
 	}{[]string{"a", "b", "c"}}
 	v, err := Values(s)
 	if err != nil {


### PR DESCRIPTION
Bit of an oversight from when the `EncodeValues` feature was originally added - it didn't contain the parameter key! This change fixes that.
