### PR TITLE
Bugfix - Invalid call to value method with nil pointer

### DIFF
--- a/query/encode.go
+++ b/query/encode.go
@@ -167,6 +167,10 @@ func reflectValue(values url.Values, val reflect.Value, scope string) error {
 		}
 
 		if sv.Type().Implements(encoderType) {
+			if !reflect.Indirect(sv).IsValid() {
+				sv = reflect.New(sv.Type().Elem())
+			}
+
 			m := sv.Interface().(Encoder)
 			if err := m.EncodeValues(name, &values); err != nil {
 				return err

--- a/query/encode_test.go
+++ b/query/encode_test.go
@@ -265,6 +265,21 @@ func TestValues_Marshaler(t *testing.T) {
 	}
 }
 
+func TestValues_MarshalerWithNilPointer(t *testing.T) {
+	s := struct {
+		Args *EncodedArgs `url:"arg"`
+	}{}
+	v, err := Values(s)
+	if err != nil {
+		t.Errorf("Values(%q) returned error: %v", s, err)
+	}
+
+	want := url.Values{}
+	if !reflect.DeepEqual(want, v) {
+		t.Errorf("Values(%q) returned %v, want %v", s, v, want)
+	}
+}
+
 func TestTagParsing(t *testing.T) {
 	name, opts := parseTag("field,foobar,foo")
 	if name != "field" {


### PR DESCRIPTION
I ran into an issue when using this library when I tried to encode a struct that contained a nil pointer with a custom encoding method (through the `query.Encoder` interface) that had a value type receiver.

Due to the way that this library was checking for and asserting the interface on a reflected value, it could end up naïvely calling the interface method on a nil pointer. The only option to circumvent the issue was to instead define the `query.Encoder` interface's `EncodeValues` method with a pointer receiver and check for a `nil` receiver, but then non-pointers (value types) wouldn't implement the interface and wouldn't call the custom encoding method, which is obviously very limiting.

This PR makes simply adds a fail-safe by getting an indirect reflection value of the existing value, checking it's validity, and initializing the pointed with a proper zero value before calling the `EncodeValues` method on it.