### PR TITLE
Bugfix - Go 1.6 reflect embedded unexported field access

### DIFF
--- a/query/encode.go
+++ b/query/encode.go
@@ -138,7 +138,7 @@ func reflectValue(values url.Values, val reflect.Value, scope string) error {
 	typ := val.Type()
 	for i := 0; i < typ.NumField(); i++ {
 		sf := typ.Field(i)
-		if sf.PkgPath != "" { // unexported
+		if sf.PkgPath != "" && !sf.Anonymous { // unexported
 			continue
 		}
 

--- a/query/encode_test.go
+++ b/query/encode_test.go
@@ -203,6 +203,15 @@ type D struct {
 	C string
 }
 
+type e struct {
+	B
+	C string
+}
+
+type F struct {
+	e
+}
+
 func TestValues_embeddedStructs(t *testing.T) {
 	tests := []struct {
 		in   interface{}
@@ -214,6 +223,10 @@ func TestValues_embeddedStructs(t *testing.T) {
 		},
 		{
 			D{B: B{C: "bar"}, C: "foo"},
+			url.Values{"C": {"foo", "bar"}},
+		},
+		{
+			F{e{B: B{C: "bar"}, C: "foo"}}, // With unexported embed
 			url.Values{"C": {"foo", "bar"}},
 		},
 	}


### PR DESCRIPTION
This fixes an incompatibility introduced in Go 1.6.

This PR updates the reflective struct walking in the `reflectValue()` method to check if a field is not anonymous before skipping it, making sure that we don't skip validly accessible (exported) embedded values in an unexported field.

This new checking logic is the new recommended strategy for reflective struct walking as of the Go 1.6 release.

Related/References:

- Go 1.6 reflect release note: https://golang.org/doc/go1.6#reflect
- Issue: https://golang.org/issue/12367
    (golang/go#12367)
- CL: https://golang.org/cl/14085
    (https://go-review.googlesource.com/#/c/14085/)
- Commit: golang/go@afe9837