### PR TITLE
New array handling options (semicolon, numbered)

### DIFF
--- a/query/encode.go
+++ b/query/encode.go
@@ -88,8 +88,11 @@ type Encoder interface {
 // same name.  Including the "comma" option signals that the field should be
 // encoded as a single comma-delimited value.  Including the "space" option
 // similarly encodes the value as a single space-delimited string. Including
-// the "brackets" option signals that the multiple URL values should have "[]"
-// appended to the value name.
+// the "semicolon" option will encode the value as a semicolon-delimited string.
+// Including the "brackets" option signals that the multiple URL values should
+// have "[]" appended to the value name. "numbered" will append a number to
+// the end of each incidence of the value name, example:
+// name0=value0&name1=value1, etc.
 //
 // Anonymous struct fields are usually encoded as if their inner exported
 // fields were fields in the outer struct, subject to the standard Go
@@ -184,6 +187,8 @@ func reflectValue(values url.Values, val reflect.Value, scope string) error {
 				del = ','
 			} else if opts.Contains("space") {
 				del = ' '
+			} else if opts.Contains("semicolon") {
+				del = ';'
 			} else if opts.Contains("brackets") {
 				name = name + "[]"
 			}
@@ -202,7 +207,11 @@ func reflectValue(values url.Values, val reflect.Value, scope string) error {
 				values.Add(name, s.String())
 			} else {
 				for i := 0; i < sv.Len(); i++ {
-					values.Add(name, valueString(sv.Index(i), opts))
+					k := name
+					if opts.Contains("numbered") {
+						k = fmt.Sprintf("%s%d", name, i)
+					}
+					values.Add(k, valueString(sv.Index(i), opts))
 				}
 			}
 			continue

--- a/query/encode_test.go
+++ b/query/encode_test.go
@@ -72,6 +72,8 @@ func TestValues_types(t *testing.T) {
 				G []*string `url:",space"`
 				H []bool    `url:",int,space"`
 				I []string  `url:",brackets"`
+				J []string  `url:",semicolon"`
+				K []string  `url:",numbered"`
 			}{
 				A: []string{"a", "b"},
 				B: []string{"a", "b"},
@@ -82,6 +84,8 @@ func TestValues_types(t *testing.T) {
 				G: []*string{&str, &str},
 				H: []bool{true, false},
 				I: []string{"a", "b"},
+				J: []string{"a", "b"},
+				K: []string{"a", "b"},
 			},
 			url.Values{
 				"A":   {"a", "b"},
@@ -93,6 +97,9 @@ func TestValues_types(t *testing.T) {
 				"G":   {"string string"},
 				"H":   {"1 0"},
 				"I[]": {"a", "b"},
+				"J":   {"a;b"},
+				"K0":  {"a"},
+				"K1":  {"b"},
 			},
 		},
 		{


### PR DESCRIPTION
I've created this PR to help facilitate using this library with the [Pingdom API](https://www.pingdom.com/resources/api), which has some interesting query string idioms, such as delimiting off of semicolons, and numbering their multiple query values.

Vendoring and including this in https://github.com/paybyphone/pingdom-go-sdk
Which will be used in my efforts to get Pingdom into [Terraform](https://terraform.io/)

Included update GoDoc and tests as well. 

I will work on submitting a CLA on Monday!

