### PR TITLE
Add default formatting options

### DIFF
--- a/query/encode.go
+++ b/query/encode.go
@@ -30,9 +30,10 @@ import (
 	"time"
 )
 
-var timeType = reflect.TypeOf(time.Time{})
-
-var encoderType = reflect.TypeOf(new(Encoder)).Elem()
+var (
+	timeType    = reflect.TypeOf(time.Time{})
+	encoderType = reflect.TypeOf(new(Encoder)).Elem()
+)
 
 // Encoder is an interface implemented by any type that wishes to encode
 // itself into URL values in a non-standard way.

--- a/query/encode_test.go
+++ b/query/encode_test.go
@@ -300,8 +300,30 @@ func TestValues_MarshalerWithNilPointer(t *testing.T) {
 	}
 }
 
+func TestValuesWithOpts_NoOverride(t *testing.T) {
+	s := struct {
+		A []int
+		B []int `url:"b,brackets"`
+	}{
+		A: []int{1, 2, 3},
+		B: []int{4, 5, 6},
+	}
+	v, err := ValuesWithOpts(s, []string{"comma"})
+	if err != nil {
+		t.Errorf("Values(%q) returned error: %v", s, err)
+	}
+
+	want := url.Values{
+		"A":   {"1,2,3"},
+		"b[]": {"4", "5", "6"},
+	}
+	if !reflect.DeepEqual(want, v) {
+		t.Errorf("Values(%q) returned %v, want %v", s, v, want)
+	}
+}
+
 func TestTagParsing(t *testing.T) {
-	name, opts := parseTag("field,foobar,foo")
+	name, opts := parseTag("field,foobar,foo", nil)
 	if name != "field" {
 		t.Fatalf("name = %q, want field", name)
 	}


### PR DESCRIPTION
These changes allow setting default formatting options either (a) globally or (b) for a single struct. This addresses the case where you would otherwise have to go through and add all of these options to each struct individually, which could be error prone in large systems.

The default behavior is obviously left intact, but each application may decide the best way to manage encoding for itself, either by calling ValuesWithOpts() or by setting DefaultOpts.
