### PR TITLE
Add noexponent option for float data type

### DIFF
--- a/query/encode.go
+++ b/query/encode.go
@@ -255,22 +255,25 @@ func valueString(v reflect.Value, opts tagOptions) string {
 		v = v.Elem()
 	}
 
-	if v.Kind() == reflect.Bool && opts.Contains("int") {
+	switch {
+	case v.Kind() == reflect.Bool && opts.Contains("int"):
 		if v.Bool() {
 			return "1"
 		}
 		return "0"
-	}
-
-	if v.Type() == timeType {
+	case v.Kind() == reflect.Float32 && opts.Contains("noexponent"):
+		return strconv.FormatFloat(v.Float(), 'f', -1, 32)
+	case v.Kind() == reflect.Float64 && opts.Contains("noexponent"):
+		return strconv.FormatFloat(v.Float(), 'f', -1, 64)
+	case v.Type() == timeType:
 		t := v.Interface().(time.Time)
 		if opts.Contains("unix") {
 			return strconv.FormatInt(t.Unix(), 10)
 		}
 		return t.Format(time.RFC3339)
+	default:
+		return fmt.Sprint(v.Interface())
 	}
-
-	return fmt.Sprint(v.Interface())
 }
 
 // isEmptyValue checks if a value should be considered empty for the purposes

--- a/query/encode_test.go
+++ b/query/encode_test.go
@@ -39,6 +39,7 @@ func TestValues_types(t *testing.T) {
 				C uint
 				D float32
 				E bool
+				F float64
 			}{},
 			url.Values{
 				"A": {""},
@@ -46,6 +47,7 @@ func TestValues_types(t *testing.T) {
 				"C": {"0"},
 				"D": {"0"},
 				"E": {"false"},
+				"F": {"0"},
 			},
 		},
 		{
@@ -116,17 +118,23 @@ func TestValues_types(t *testing.T) {
 				B time.Time `url:",unix"`
 				C bool      `url:",int"`
 				D bool      `url:",int"`
+				E float32   `url:",noexponent"`
+				F float64   `url:",noexponent"`
 			}{
 				A: time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC),
 				B: time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC),
 				C: true,
 				D: false,
+				E: 1.23450,
+				F: 1.234567890,
 			},
 			url.Values{
 				"A": {"2000-01-01T12:34:56Z"},
 				"B": {"946730096"},
 				"C": {"1"},
 				"D": {"0"},
+				"E": {"1.2345"},
+				"F": {"1.23456789"},
 			},
 		},
 		{


### PR DESCRIPTION
Currently the float data types will be converted to exponent/electronic value.