### PR TITLE
introduce combination of "brackets" and "numbered" option on slices

### DIFF
--- a/query/encode_test.go
+++ b/query/encode_test.go
@@ -81,6 +81,7 @@ func TestValues_types(t *testing.T) {
 				I []string  `url:",brackets"`
 				J []string  `url:",semicolon"`
 				K []string  `url:",numbered"`
+				L []string  `url:",brackets,numbered"`
 			}{
 				A: []string{"a", "b"},
 				B: []string{"a", "b"},
@@ -93,20 +94,23 @@ func TestValues_types(t *testing.T) {
 				I: []string{"a", "b"},
 				J: []string{"a", "b"},
 				K: []string{"a", "b"},
+				L: []string{"a", "b"},
 			},
 			url.Values{
-				"A":   {"a", "b"},
-				"B":   {"a,b"},
-				"C":   {"a b"},
-				"D":   {"a", "b"},
-				"E":   {"a,b"},
-				"F":   {"a b"},
-				"G":   {"string string"},
-				"H":   {"1 0"},
-				"I[]": {"a", "b"},
-				"J":   {"a;b"},
-				"K0":  {"a"},
-				"K1":  {"b"},
+				"A":    {"a", "b"},
+				"B":    {"a,b"},
+				"C":    {"a b"},
+				"D":    {"a", "b"},
+				"E":    {"a,b"},
+				"F":    {"a b"},
+				"G":    {"string string"},
+				"H":    {"1 0"},
+				"I[]":  {"a", "b"},
+				"J":    {"a;b"},
+				"K0":   {"a"},
+				"K1":   {"b"},
+				"L[0]": {"a"},
+				"L[1]": {"b"},
 			},
 		},
 		{


### PR DESCRIPTION
This PR introduces the combination of "brackets" and "numbered" option on slices to provide indexed brackets in the URL.

Given 
```go
p := struct{
   Values []string `url:"key,brackets,numbered"`
}{
  Values []string{"value0", "value1"},
}
```

Currently this combination is possible but would lead to something like
`key[]0=value0&key[]1=value1`

This behavior will be changed to something similar like this PHP method would create:
https://www.php.net/manual/en/function.http-build-query.php

The upper example would look like this:
`key[0]=value0&key[1]=value1`

While there is nothing wrong with the brackets only syntax, some APIs, e.g. LinkedIn Ads API simply insist on the indexed brackets syntax. I'm aware this can be created with maps, but still this might be a useful extension.