### PR TITLE
update `dotnumbered` and `numbered1` opt

### DIFF
--- a/query/encode.go
+++ b/query/encode.go
@@ -92,7 +92,12 @@ type Encoder interface {
 // Including the "brackets" option signals that the multiple URL values should
 // have "[]" appended to the value name. "numbered" will append a number to
 // the end of each incidence of the value name, example:
-// name0=value0&name1=value1, etc.
+// name0=value0&name1=value1, etc.  "dotnumbered" will append a number with a dot
+// to the end of each incidence of the value name, example:
+// name.0=value0&name.1=value1, etc.  "numbered1" will append a number
+// which start with 1 instead of 0 to the end of each incidence of the value name,
+// example:
+// name1=value0&name2=value1, etc.
 //
 // Anonymous struct fields are usually encoded as if their inner exported
 // fields were fields in the outer struct, subject to the standard Go
@@ -207,9 +212,22 @@ func reflectValue(values url.Values, val reflect.Value, scope string) error {
 				values.Add(name, s.String())
 			} else {
 				for i := 0; i < sv.Len(); i++ {
+					var n int
+					// number start with 1 instead of 0
+					if opts.Contains("numbered1") {
+						n = i + 1
+					} else {
+						n = i
+					}
+
 					k := name
+					// add number, such as "address0"
 					if opts.Contains("numbered") {
-						k = fmt.Sprintf("%s%d", name, i)
+						k = fmt.Sprintf("%s%d", name, n)
+					}
+					// add number with dot , such as "address.0"
+					if opts.Contains("dotnumbered") {
+						k = fmt.Sprintf("%s.%d", name, n)
 					}
 					values.Add(k, valueString(sv.Index(i), opts))
 				}

--- a/query/encode_test.go
+++ b/query/encode_test.go
@@ -81,6 +81,8 @@ func TestValues_types(t *testing.T) {
 				I []string  `url:",brackets"`
 				J []string  `url:",semicolon"`
 				K []string  `url:",numbered"`
+				L []string  `url:",dotnumbered"`
+				M []string  `url:",numberd1"`
 			}{
 				A: []string{"a", "b"},
 				B: []string{"a", "b"},
@@ -93,6 +95,8 @@ func TestValues_types(t *testing.T) {
 				I: []string{"a", "b"},
 				J: []string{"a", "b"},
 				K: []string{"a", "b"},
+				L: []string{"a", "b"},
+				M: []string{"a", "b"},
 			},
 			url.Values{
 				"A":   {"a", "b"},
@@ -107,6 +111,10 @@ func TestValues_types(t *testing.T) {
 				"J":   {"a;b"},
 				"K0":  {"a"},
 				"K1":  {"b"},
+				"L.0": {"a"},
+				"L.1": {"b"},
+				"M1":  {"a"},
+				"M2":  {"b"},
 			},
 		},
 		{
@@ -325,4 +333,23 @@ func TestTagParsing(t *testing.T) {
 			t.Errorf("Contains(%q) = %v", tt.opt, !tt.want)
 		}
 	}
+}
+
+type Person struct {
+	Name    string   `url:"name,omitempty"`
+	Age     int      `url:"age,omitempty"`
+	Address []string `url:"address,omitempty,dotnumbered,numbered1"`
+}
+
+var user = Person{
+	Name:    "zhangsan",
+	Age:     10,
+	Address: []string{"sichuan", "chengdu"},
+}
+
+func Test_Manual(t *testing.T) {
+
+	values, _ := Values(user)
+	fmt.Println(values)
+	fmt.Println(values.Encode())
 }


### PR DESCRIPTION
# add 2 opts

+ `dotnumbered`  will append a number with a dot to the end of each incidence of the value name, example:
`name.0=value0&name.1=value1`, etc.  

+ `numbered1` will append a number which start with 1 instead of 0 to the end of each incidence of the value name, example:
`name1=value0&name2=value1`, etc.


```go
type Person struct {
	Name    string   `url:"name,omitempty"`
	Age     int      `url:"age,omitempty"`
	Address []string `url:"address,omitempty,dotnumbered,numbered1"`
}

var user = Person{
	Name:    "zhangsan",
	Age:     10,
	Address: []string{"sichuan", "chengdu"},
}

func Test_Manual(t *testing.T) {

	values, _ := Values(user)
	fmt.Println(values)
	fmt.Println(values.Encode())  // address.1=sichuan&address.2=chengdu&age=10&name=zhangsan
}
```