### PR TITLE
Fix encoding non-nil slice pointers by their by using their actual value

### DIFF
--- a/query/encode.go
+++ b/query/encode.go
@@ -151,6 +151,7 @@ func reflectValue(values url.Values, val reflect.Value, scope string) error {
 			continue
 		}
 		name, opts := parseTag(tag)
+
 		if name == "" {
 			if sf.Anonymous && sv.Kind() == reflect.Struct {
 				// save embedded struct for later processing
@@ -167,6 +168,13 @@ func reflectValue(values url.Values, val reflect.Value, scope string) error {
 
 		if opts.Contains("omitempty") && isEmptyValue(sv) {
 			continue
+		}
+
+		for sv.Kind() == reflect.Ptr {
+			if sv.IsNil() {
+				break
+			}
+			sv = sv.Elem()
 		}
 
 		if sv.Type().Implements(encoderType) {
@@ -215,13 +223,6 @@ func reflectValue(values url.Values, val reflect.Value, scope string) error {
 				}
 			}
 			continue
-		}
-
-		for sv.Kind() == reflect.Ptr {
-			if sv.IsNil() {
-				break
-			}
-			sv = sv.Elem()
 		}
 
 		if sv.Type() == timeType {

--- a/query/encode_test.go
+++ b/query/encode_test.go
@@ -25,6 +25,7 @@ type SubNested struct {
 func TestValues_types(t *testing.T) {
 	str := "string"
 	strPtr := &str
+	strSlice := []string{"a", "b"}
 	timeVal := time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC)
 
 	tests := []struct {
@@ -81,6 +82,7 @@ func TestValues_types(t *testing.T) {
 				I []string  `url:",brackets"`
 				J []string  `url:",semicolon"`
 				K []string  `url:",numbered"`
+				L *[]string `url:",brackets"`
 			}{
 				A: []string{"a", "b"},
 				B: []string{"a", "b"},
@@ -93,6 +95,7 @@ func TestValues_types(t *testing.T) {
 				I: []string{"a", "b"},
 				J: []string{"a", "b"},
 				K: []string{"a", "b"},
+				L: &strSlice,
 			},
 			url.Values{
 				"A":   {"a", "b"},
@@ -107,6 +110,7 @@ func TestValues_types(t *testing.T) {
 				"J":   {"a;b"},
 				"K0":  {"a"},
 				"K1":  {"b"},
+				"L[]": {"a", "b"},
 			},
 		},
 		{


### PR DESCRIPTION
As described in issue #26 if we unwrap the value of the pointer prior to the slice/array logic this should work. It is placed under the omitempty check, since this would be backwards breaking.