### PR TITLE
Added support for unix nano and milliseconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,17 @@ The query package exports a single `Values()` function.  A simple example:
 
 ```go
 type Options struct {
-  Query   string `url:"q"`
-  ShowAll bool   `url:"all"`
-  Page    int    `url:"page"`
+  Query       string     `url:"q"`
+  ShowAll     bool       `url:"all"`
+  Page        int        `url:"page"`
+  UnixSecond  time.Time  `url:"seconds,unix"`
+  UnixMilli   time.Time  `url:"millis,epochmilli"`
+  UnixNano    time.Time  `url:"nano,epochnano"`
 }
 
 opt := Options{ "foo", true, 2 }
 v, _ := query.Values(opt)
-fmt.Print(v.Encode()) // will output: "q=foo&all=true&page=2"
+fmt.Print(v.Encode()) // will output: "q=foo&all=true&page=2&seconds=123456789&millis=123456789000&nano=12345678000000000"
 ```
 
 [go-github]: https://github.com/google/go-github/commit/994f6f8405f052a117d2d0b500054341048fbb08

--- a/query/encode.go
+++ b/query/encode.go
@@ -270,6 +270,12 @@ func valueString(v reflect.Value, opts tagOptions) string {
 		if opts.Contains("unix") {
 			return strconv.FormatInt(t.Unix(), 10)
 		}
+		if opts.Contains("epochmilli") {
+			return strconv.FormatInt((t.UnixNano() / 1000000), 10)
+		}
+		if opts.Contains("epochnano") {
+			return strconv.FormatInt(t.UnixNano(), 10)
+		}
 		return t.Format(time.RFC3339)
 	}
 

--- a/query/encode_test.go
+++ b/query/encode_test.go
@@ -72,6 +72,18 @@ func TestValues_BasicTypes(t *testing.T) {
 			}{time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC)},
 			url.Values{"V": {"946730096"}},
 		},
+		{
+			struct {
+				V time.Time `url:",epochmilli"`
+			}{time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC)},
+			url.Values{"V": {"946730096000"}},
+		},
+		{
+			struct {
+				V time.Time `url:",epochnano"`
+			}{time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC)},
+			url.Values{"V": {"946730096000000000"}},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Hi,
This library is very useful to me. However, I needed support for Unix epoch-seconds time format with millisecond and nanosecond granularity.

- I've added support for unix epoch-seconds will millisecond and nanosecond granularity. ( with tests )
- I added the time.Time type and options to the example struct in README.md as well. 