### PR TITLE
Add support for nested indexed type, fixes issue #9

### DIFF
--- a/query/tag_parser.go
+++ b/query/tag_parser.go
@@ -1,0 +1,39 @@
+package query
+
+import "strings"
+
+type urlTag struct {
+	name    string
+	options tagOptions
+}
+
+type tagOptions []string
+
+// Contains checks whether the tagOptions contains the specified option.
+func (o tagOptions) Contains(option string) bool {
+	for _, s := range o {
+		if s == option {
+			return true
+		}
+	}
+	return false
+}
+
+const tagStringComma = "comma"
+const tagStringSpace = "space"
+const tagStringSemicolon = "semicolon"
+const tagStringBrackets = "brackets"
+const tagStringNumbered = "numbered"
+const tagStringIndexed = "indexed"
+const tagStringInt = "int"
+const tagStringUnix = "unix"
+const tagStringUnixMilli = "unixmilli"
+const tagStringUnixNano = "unixnano"
+const tagStringOmitEmpty = "omitempty"
+
+// parseTag splits a struct field's url tag into its name and comma-separated
+// options.
+func parseTag(tag string) urlTag {
+	s := strings.Split(tag, ",")
+	return urlTag{s[0], s[1:]}
+}

--- a/query/tag_parser_test.go
+++ b/query/tag_parser_test.go
@@ -1,0 +1,24 @@
+package query
+
+import "testing"
+
+func TestParseTag(t *testing.T) {
+	parsedTag := parseTag("field,foobar,foo")
+	if parsedTag.name != "field" {
+
+		t.Fatalf("name = %q, want field", parsedTag.name)
+	}
+	for _, tt := range []struct {
+		opt  string
+		want bool
+	}{
+		{"foobar", true},
+		{"foo", true},
+		{"bar", false},
+		{"field", false},
+	} {
+		if parsedTag.options.Contains(tt.opt) != tt.want {
+			t.Errorf("Contains(%q) = %v", tt.opt, !tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Hi there Authors, Maintainers and Collaborators, 

I stumbled upon #8  and saw that it was still open, I am learning golang these days so wanted to learn as well as start contributing to open source. Please accept, in case you think it's a good addition, it was a great learning experience, especially about the `reflect` library.

This PR features following updates

-  Ability to add index within brackets using indexed tag string
- Ability to recurse over the structs within the slices, leading to something like arr[0][a] for a struct that looks like the following
```
struct {
  arr []struct{ A string }
}
```
- I am not sure if this ability is provided by rubygems, as I haven't worked with ruby but the test case in #8 does list this in test case
- Refactoring of the genericTestRunner to use DRY principle
- Refactoring of the tagParser to use constant strings within the encode.go, in order to reduce the chances of future mistakes

### Further improvements

I have a few more features in mind and would add these and open issues at your discretion

- Support Multi Dimensional Array query string conversion, it seems rails doesn't provide this ability for now [source](https://stackoverflow.com/questions/12397276/pass-multidimensional-array-in-query-string-to-controller-in-rails)
- Pre-parse the options of a tag for a micro-optimization purpose, for rest of the encode.go we could use something faster than string comparison maybe, such as iota, I recently stumbled on that
- Benchmark comparisons with rest of the libraries 

Thank you for the library, It's amazing! 
