### PR TITLE
Add support for JSON encoding nested struct

### DIFF
--- a/query/encode.go
+++ b/query/encode.go
@@ -263,11 +263,12 @@ func reflectValue(values url.Values, val reflect.Value, scope string) error {
 		if sv.Kind() == reflect.Struct {
 			if opts.Contains("json") {
 				var b []byte
-				if b, err := json.Marshal(sv); err != nil {
+				b, err := json.Marshal(sv.Interface())
+				if err != nil {
 					return err
 				}
 
-				values.Add(name, valueString(string(b), opts, sf))
+				values.Add(name, valueString(reflect.ValueOf(string(b)), opts, sf))
 			} else {
 				if err := reflectValue(values, sv, name); err != nil {
 					return err

--- a/query/encode.go
+++ b/query/encode.go
@@ -22,6 +22,7 @@ package query
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -262,7 +263,7 @@ func reflectValue(values url.Values, val reflect.Value, scope string) error {
 		if sv.Kind() == reflect.Struct {
 			if opts.Contains("json") {
 				var b []byte
-				if b, err := json.Marshall(sv); err != nil {
+				if b, err := json.Marshal(sv); err != nil {
 					return err
 				}
 

--- a/query/encode_test.go
+++ b/query/encode_test.go
@@ -404,6 +404,54 @@ func TestValues_EmbeddedStructs(t *testing.T) {
 	}
 }
 
+
+func TestValues_StructsAsJSON(t *testing.T) {
+	type Inner struct {
+		A string `json:"a"`
+		B int `json:"b"`
+		T struct {
+			L bool `json:"l"`
+			M bool `json:"m"`
+		} `json:"t"`
+	}
+
+	type Outer struct {
+		S Inner `url:"str,json"`
+		P *Inner `url:"ptr,json,omitempty"`
+	}
+
+	tests := []struct {
+		input interface{}
+		want  url.Values
+	}{
+		{
+			Outer {
+				S: Inner {
+					A: "abc",
+					B: 5,
+					T: struct {
+						L bool `json:"l"`
+						M bool `json:"m"`
+					} `json:"t"`,
+				},
+				P: nil,
+			},
+			url.Values{
+				"str": {"{\"a\": \"abc\", \"b\": 5, \"t\": {\"l\": false, \"m\": false}}"},
+				"ptr": {""},
+			},
+		},
+		{
+			nil,
+			url.Values{},
+		},
+	}
+
+	for _, tt := range tests {
+		testValue(t, tt.input, tt.want)
+	}
+}
+
 func TestValues_InvalidInput(t *testing.T) {
 	_, err := Values("")
 	if err == nil {

--- a/query/encode_test.go
+++ b/query/encode_test.go
@@ -404,19 +404,19 @@ func TestValues_EmbeddedStructs(t *testing.T) {
 	}
 }
 
-
 func TestValues_StructsAsJSON(t *testing.T) {
+	type Nested struct {
+		L bool `json:"l"`
+		M bool `json:"m"`
+	}
 	type Inner struct {
 		A string `json:"a"`
-		B int `json:"b"`
-		T struct {
-			L bool `json:"l"`
-			M bool `json:"m"`
-		} `json:"t"`
+		B int    `json:"b"`
+		T Nested `json:"t"`
 	}
 
 	type Outer struct {
-		S Inner `url:"str,json"`
+		S Inner  `url:"str,json"`
 		P *Inner `url:"ptr,json,omitempty"`
 	}
 
@@ -425,20 +425,19 @@ func TestValues_StructsAsJSON(t *testing.T) {
 		want  url.Values
 	}{
 		{
-			Outer {
-				S: Inner {
+			Outer{
+				S: Inner{
 					A: "abc",
 					B: 5,
-					T: struct {
-						L bool `json:"l"`
-						M bool `json:"m"`
-					} `json:"t"`,
+					T: Nested{
+						L: true,
+						M: false,
+					},
 				},
 				P: nil,
 			},
 			url.Values{
-				"str": {"{\"a\": \"abc\", \"b\": 5, \"t\": {\"l\": false, \"m\": false}}"},
-				"ptr": {""},
+				"str": {`{"a":"abc","b":5,"t":{"l":true,"m":false}}`},
 			},
 		},
 		{

--- a/query/encode_test.go
+++ b/query/encode_test.go
@@ -441,6 +441,28 @@ func TestValues_StructsAsJSON(t *testing.T) {
 			},
 		},
 		{
+			Outer{
+				P: &Inner{
+					A: "def",
+					B: 22,
+					T: Nested{
+						L: true,
+						M: true,
+					},
+				},
+			},
+			url.Values{
+				"str": {`{"a":"","b":0,"t":{"l":false,"m":false}}`},
+				"ptr": {`{"a":"def","b":22,"t":{"l":true,"m":true}}`},
+			},
+		},
+		{
+			Outer{},
+			url.Values{
+				"str": {`{"a":"","b":0,"t":{"l":false,"m":false}}`},
+			},
+		},
+		{
 			nil,
 			url.Values{},
 		},


### PR DESCRIPTION
Resolves #53 

```
// Structs can be encoded as JSON by including the "json" option in that fields
// tag. The entire struct is then passed to encoding/json.Marshal where those
// tag signatures apply.
//
//  // Encoding a struct as JSON
//  Field A `url: "myName,json"`
//  // Result: myName={"someField": "cat", "numField": 1}
//
```