### PR TITLE
fixed time layout for time.Time pointer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-querystring
+module github.com/lmindwarel/go-querystring
 
 go 1.10
 

--- a/query/encode.go
+++ b/query/encode.go
@@ -291,8 +291,14 @@ func valueString(v reflect.Value, opts tagOptions, sf reflect.StructField) strin
 		return "0"
 	}
 
-	if v.Type() == timeType {
-		t := v.Interface().(time.Time)
+	isTimePointer := (v.Kind() == reflect.Pointer && !v.IsNil() && v.Elem().Type() == timeType)
+	if v.Type() == timeType || isTimePointer {
+		var t time.Time
+		if isTimePointer {
+			t = *v.Interface().(*time.Time)
+		} else {
+			t = v.Interface().(time.Time)
+		}
 		if opts.Contains("unix") {
 			return strconv.FormatInt(t.Unix(), 10)
 		}


### PR DESCRIPTION
Bug: When using a time pointer, the layout tag wasn't used and the time is formatted to the default layout.

This pull request fix this, and the layout given in field tag is now applied to the time pointer.