### PR TITLE
New array handing options (spotnumbered)

### DIFF
--- a/query/encode.go
+++ b/query/encode.go
@@ -244,6 +244,8 @@ func reflectValue(values url.Values, val reflect.Value, scope string) error {
 					k := name
 					if opts.Contains("numbered") {
 						k = fmt.Sprintf("%s%d", name, i)
+					} else if opts.Contains("spotnumbered") {
+						k = fmt.Sprintf("%s.%d", name, i)
 					}
 					values.Add(k, valueString(sv.Index(i), opts, sf))
 				}

--- a/query/encode_test.go
+++ b/query/encode_test.go
@@ -237,7 +237,12 @@ func TestValues_Slices(t *testing.T) {
 			}{[2]string{"a", "b"}},
 			url.Values{"V0": {"a"}, "V1": {"b"}},
 		},
-
+		{
+			struct {
+				V [2]string `url:",spotnumbered"`
+			}{[2]string{"a", "b"}},
+			url.Values{"V.0": {"a"}, "V.1": {"b"}},
+		},
 		// custom delimiters
 		{
 			struct {


### PR DESCRIPTION
Hello. master. 

When using go-query, I thought that it would be good to have a spot separator in the array indexing (numberd option), so I added the source.

`struct {
     V [2]string `url:",spotnumbered"`
}

url.Values{"V.0": {"a"}, "V.1": {"b"}}
`