### PR TITLE
feat: add tag option string for struct type filed

### DIFF
--- a/query/encode.go
+++ b/query/encode.go
@@ -256,7 +256,7 @@ func reflectValue(values url.Values, val reflect.Value, scope string) error {
 			continue
 		}
 
-		if sv.Kind() == reflect.Struct {
+		if sv.Kind() == reflect.Struct && !opts.Contains("string") {
 			if err := reflectValue(values, sv, name); err != nil {
 				return err
 			}

--- a/query/encode_test.go
+++ b/query/encode_test.go
@@ -745,3 +745,35 @@ func TestParseTag(t *testing.T) {
 		}
 	}
 }
+
+type customStructString struct {
+	V string
+}
+
+func (s customStructString) String() string {
+	return s.V
+}
+
+func TestValues_CustomStructStringValue(t *testing.T) {
+	tests := []struct {
+		input interface{}
+		want  url.Values
+	}{
+		{
+			struct {
+				V customStructString `url:"v,string"`
+			}{customStructString{"a"}},
+			url.Values{"v": {"a"}},
+		},
+		{
+			struct {
+				V customStructString `url:"v"`
+			}{},
+			url.Values{"v[V]": {""}},
+		},
+	}
+
+	for _, tt := range tests {
+		testValue(t, tt.input, tt.want)
+	}
+}


### PR DESCRIPTION
Some third-part libraries like [https://github.com/shopspring/decimal](https://github.com/shopspring/decimal) is wildly used in many projects.

It's not easily to add encoder method directly, but can use `func String() string` method for encoded value.

For that purpose, add tag option `string` to force struct value use `valueString` method.