### PR TITLE
performance opt: replace bytes.Buffer with strings.Builder

### DIFF
--- a/query/encode.go
+++ b/query/encode.go
@@ -21,7 +21,6 @@
 package query
 
 import (
-	"bytes"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -229,7 +228,7 @@ func reflectValue(values url.Values, val reflect.Value, scope string) error {
 			}
 
 			if del != "" {
-				s := new(bytes.Buffer)
+				s := new(strings.Builder)
 				first := true
 				for i := 0; i < sv.Len(); i++ {
 					if first {

--- a/query/encode.go
+++ b/query/encode.go
@@ -125,16 +125,17 @@ type Encoder interface {
 // as multiple URL values of the same name.
 func Values(v interface{}) (url.Values, error) {
 	values := make(url.Values)
+
+	if v == nil {
+		return values, nil
+	}
+
 	val := reflect.ValueOf(v)
 	for val.Kind() == reflect.Ptr {
 		if val.IsNil() {
 			return values, nil
 		}
 		val = val.Elem()
-	}
-
-	if v == nil {
-		return values, nil
 	}
 
 	if val.Kind() != reflect.Struct {


### PR DESCRIPTION
a Builder is used to efficiently build a string using Write methods. it minimizes memory copying. Builder directly converts the underlying []byte to a string type and returns it.