### PR TITLE
go.mod,.github: set Go 1.13 as the minimum version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [stable, oldstable]
+        go-version: [stable, oldstable, "1.13"]
         platform: [ubuntu-latest]
         include:
           # only update test coverage stats with most recent go version on linux

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/google/go-querystring
 
-go 1.10
+go 1.13
 
 require github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
The `go.mod` file previously specified `go 1.10`, which is incorrect - Go modules were introduced in Go 1.11. I attempted to build the project using Go 1.11, but it failed because `github.com/google/go-cmp@v0.6.0` [requires Go 1.13](https://github.com/google/go-cmp/blob/v0.6.0/go.mod#L3).
Therefore, I’ve updated the `go` version in `go.mod` to `1.13`.
